### PR TITLE
Use += for appending to strings

### DIFF
--- a/quinedb
+++ b/quinedb
@@ -19,47 +19,47 @@ pr_str () {
         for (( i=0; i<${#s}; i++ )); do
             c="${s:$i:1}"
             if [[ "$c" =~ [-_a-zA-Z0-9\ ] ]]; then
-                ret="${ret}$c"
+                ret+="$c"
             else
                 case "$c" in
                     $'\a')
-                        ret="${ret}\\a"
+                        ret+="\\a"
                     ;;
                     $'\b')
-                        ret="${ret}\\b"
+                        ret+="\\b"
                     ;;
                     $'\e')
-                        ret="${ret}\\e"
+                        ret+="\\e"
                     ;;
                     $'\E')
-                        ret="${ret}\\E"
+                        ret+="\\E"
                     ;;
                     $'\f')
-                        ret="${ret}\\f"
+                        ret+="\\f"
                     ;;
                     $'\n')
-                        ret="${ret}\\n"
+                        ret+="\\n"
                     ;;
                     $'\r')
-                        ret="${ret}\\r"
+                        ret+="\\r"
                     ;;
                     $'\t')
-                        ret="${ret}\\t"
+                        ret+="\\t"
                     ;;
                     $'\v')
-                        ret="${ret}\\v"
+                        ret+="\\v"
                     ;;
                     $'\\')
-                        ret="${ret}\\\\"
+                        ret+="\\\\"
                     ;;
                     $'\'')
-                        ret="${ret}\\"\'
+                        ret+="\\"\'
                     ;;
                     $'\"')
-                        ret="${ret}\\"\"
+                        ret+="\\"\"
                     ;;
                     else)
-                        ret="${ret}\\$c"
+                        ret+="\\$c"
                 esac
             fi
         done
@@ -109,47 +109,47 @@ pr_str () {
         for (( i=0; i<${#s}; i++ )); do
             c="${s:$i:1}"
             if [[ "$c" =~ [-_a-zA-Z0-9\ ] ]]; then
-                ret="${ret}$c"
+                ret+="$c"
             else
                 case "$c" in
                     $'\a')
-                        ret="${ret}\\a"
+                        ret+="\\a"
                     ;;
                     $'\b')
-                        ret="${ret}\\b"
+                        ret+="\\b"
                     ;;
                     $'\e')
-                        ret="${ret}\\e"
+                        ret+="\\e"
                     ;;
                     $'\E')
-                        ret="${ret}\\E"
+                        ret+="\\E"
                     ;;
                     $'\f')
-                        ret="${ret}\\f"
+                        ret+="\\f"
                     ;;
                     $'\n')
-                        ret="${ret}\\n"
+                        ret+="\\n"
                     ;;
                     $'\r')
-                        ret="${ret}\\r"
+                        ret+="\\r"
                     ;;
                     $'\t')
-                        ret="${ret}\\t"
+                        ret+="\\t"
                     ;;
                     $'\v')
-                        ret="${ret}\\v"
+                        ret+="\\v"
                     ;;
                     $'\\')
-                        ret="${ret}\\\\"
+                        ret+="\\\\"
                     ;;
                     $'\'')
-                        ret="${ret}\\"\'
+                        ret+="\\"\'
                     ;;
                     $'\"')
-                        ret="${ret}\\"\"
+                        ret+="\\"\"
                     ;;
                     else)
-                        ret="${ret}\\$c"
+                        ret+="\\$c"
                 esac
             fi
         done


### PR DESCRIPTION
This seems to reduce the overhead for copying strings.

When tested on a sample of 32 random numbers in a Windows WSL
environment running Ubuntu 14.04, the commit improves time usage
from 13.355s to 11.328s.

``` Bash
for ((i=0; i<512; i++)); do j+=("$RANDOM"); done
declare -p j > testdata
e=({a,A}{b,B}{c,C}{d,D}{e,E}{f,F}{g,G}{H,h}{i,I})
declare -p e >> testdata

time {
  for ((i=0; i<32; i++)); do
    bash ./quinedb set "${e[i]}" "${j[i]}" > qdb.out
    mv qdb.out quinedb
  done
}
```

```
Before:
real    0m13.355s
user    0m0.734s
sys     0m12.469s

After:
real    0m11.328s
user    0m0.578s
sys     0m10.859s
```
