### PR TITLE
Use `printf %q` for simplicity and binary safety

### DIFF
--- a/quinedb
+++ b/quinedb
@@ -101,7 +101,7 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "keys")
-        printf '%q\n' "${!db[@]}" >&2
+        if ((${#db[@]})); then printf '%q\n' "${!db[@]}"; fi >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2
@@ -147,7 +147,7 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "keys")
-        printf '%q\n' "${!db[@]}" >&2
+        if ((${#db[@]})); then printf '%q\n' "${!db[@]}"; fi >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2

--- a/quinedb
+++ b/quinedb
@@ -97,11 +97,11 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "delete")
-        unset db["$2"]
+        unset 'db[$2]'
         echo 'OK' >&2
     ;;
     "keys")
-        for k in "${!db[@]}"; do echo "$(printf %q "$k")"; done >&2
+        printf '%q\n' "${!db[@]}" >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2
@@ -143,11 +143,11 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "delete")
-        unset db["$2"]
+        unset 'db[$2]'
         echo 'OK' >&2
     ;;
     "keys")
-        for k in "${!db[@]}"; do echo "$(printf %q "$k")"; done >&2
+        printf '%q\n' "${!db[@]}" >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2

--- a/quinedb
+++ b/quinedb
@@ -10,79 +10,22 @@ declare -A db
 db=(
 )
 
-pr_str () {
-    s="$1"
-    if [[ "$s" =~ ^[-a-zA-Z0-9]+$ ]]; then
-        echo "$s"
-    else
-        ret=\$\'
-        for (( i=0; i<${#s}; i++ )); do
-            c="${s:$i:1}"
-            if [[ "$c" =~ [-_a-zA-Z0-9\ ] ]]; then
-                ret+="$c"
-            else
-                case "$c" in
-                    $'\a')
-                        ret+="\\a"
-                    ;;
-                    $'\b')
-                        ret+="\\b"
-                    ;;
-                    $'\e')
-                        ret+="\\e"
-                    ;;
-                    $'\E')
-                        ret+="\\E"
-                    ;;
-                    $'\f')
-                        ret+="\\f"
-                    ;;
-                    $'\n')
-                        ret+="\\n"
-                    ;;
-                    $'\r')
-                        ret+="\\r"
-                    ;;
-                    $'\t')
-                        ret+="\\t"
-                    ;;
-                    $'\v')
-                        ret+="\\v"
-                    ;;
-                    $'\\')
-                        ret+="\\\\"
-                    ;;
-                    $'\'')
-                        ret+="\\"\'
-                    ;;
-                    $'\"')
-                        ret+="\\"\"
-                    ;;
-                    else)
-                        ret+="\\$c"
-                esac
-            fi
-        done
-        echo "${ret}"\'
-    fi
-}
-
 print_db(){
     echo "db=("
     i=0
     for k in "${!db[@]}"; do
-        escaped_keys[$i]=$(pr_str "$k")
+        escaped_keys[$i]=$(printf %q "$k")
         i=$((i+1))
     done
 
     # sort the keys for deterministic printing
-    IFS=$'\n' sorted=($(for l in ${escaped_keys[@]}; do echo $l; done | sort))
+    IFS=$'\n' sorted=($(printf '%s' "${escaped_keys[*]}" | sort))
     unset IFS
 
     for k in "${sorted[@]}"; do
         unescaped=$(eval "echo $k")
         v=${db["$unescaped"]}
-        echo "    [$k]=$(pr_str "$v")"
+        echo "    [$k]=$(printf %q "$v")"
     done
     echo ")"
 }
@@ -100,79 +43,22 @@ EOF
 )
 
 SEC2=$(cat <<'EOF'
-pr_str () {
-    s="$1"
-    if [[ "$s" =~ ^[-a-zA-Z0-9]+$ ]]; then
-        echo "$s"
-    else
-        ret=\$\'
-        for (( i=0; i<${#s}; i++ )); do
-            c="${s:$i:1}"
-            if [[ "$c" =~ [-_a-zA-Z0-9\ ] ]]; then
-                ret+="$c"
-            else
-                case "$c" in
-                    $'\a')
-                        ret+="\\a"
-                    ;;
-                    $'\b')
-                        ret+="\\b"
-                    ;;
-                    $'\e')
-                        ret+="\\e"
-                    ;;
-                    $'\E')
-                        ret+="\\E"
-                    ;;
-                    $'\f')
-                        ret+="\\f"
-                    ;;
-                    $'\n')
-                        ret+="\\n"
-                    ;;
-                    $'\r')
-                        ret+="\\r"
-                    ;;
-                    $'\t')
-                        ret+="\\t"
-                    ;;
-                    $'\v')
-                        ret+="\\v"
-                    ;;
-                    $'\\')
-                        ret+="\\\\"
-                    ;;
-                    $'\'')
-                        ret+="\\"\'
-                    ;;
-                    $'\"')
-                        ret+="\\"\"
-                    ;;
-                    else)
-                        ret+="\\$c"
-                esac
-            fi
-        done
-        echo "${ret}"\'
-    fi
-}
-
 print_db(){
     echo "db=("
     i=0
     for k in "${!db[@]}"; do
-        escaped_keys[$i]=$(pr_str "$k")
+        escaped_keys[$i]=$(printf %q "$k")
         i=$((i+1))
     done
 
     # sort the keys for deterministic printing
-    IFS=$'\n' sorted=($(for l in ${escaped_keys[@]}; do echo $l; done | sort))
+    IFS=$'\n' sorted=($(printf '%s' "${escaped_keys[*]}" | sort))
     unset IFS
 
     for k in "${sorted[@]}"; do
         unescaped=$(eval "echo $k")
         v=${db["$unescaped"]}
-        echo "    [$k]=$(pr_str "$v")"
+        echo "    [$k]=$(printf %q "$v")"
     done
     echo ")"
 }
@@ -201,9 +87,9 @@ print_self(){
 
 case "$1" in
     "get")
-        if [ ${db["$2"]+_} ]; then
+        if [ "${db["$2"]+_}" ]; then
             v=${db["$2"]}
-            echo "$(pr_str "$v")" >&2
+            echo "$(printf %q "$v")" >&2
         fi
     ;;
     "set")
@@ -215,7 +101,7 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "keys")
-        for k in "${!db[@]}"; do echo "$(pr_str "$k")"; done >&2
+        for k in "${!db[@]}"; do echo "$(printf %q "$k")"; done >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2
@@ -247,9 +133,9 @@ print_self(){
 
 case "$1" in
     "get")
-        if [ ${db["$2"]+_} ]; then
+        if [ "${db["$2"]+_}" ]; then
             v=${db["$2"]}
-            echo "$(pr_str "$v")" >&2
+            echo "$(printf %q "$v")" >&2
         fi
     ;;
     "set")
@@ -261,7 +147,7 @@ case "$1" in
         echo 'OK' >&2
     ;;
     "keys")
-        for k in "${!db[@]}"; do echo "$(pr_str "$k")"; done >&2
+        for k in "${!db[@]}"; do echo "$(printf %q "$k")"; done >&2
     ;;
     *)
         echo "USAGE: quinedb [get k | set k v | delete k | keys]" >&2

--- a/test.rb
+++ b/test.rb
@@ -24,9 +24,7 @@ class ILoveOOP < Test::Unit::TestCase
   end
 
   def pr_str s
-    s2 = ""
-    (0...(s.length)).each{|i|s2 << "\\#{s[i]}"}
-    s2
+  	"'#{s.gsub(/'/, "'\\\\''")}'"
   end
 
   def cmd *args


### PR DESCRIPTION
Minor performance improvement from 11.331s to 10.937s.

Now it's able to hold arbitrary null-terminated bytes. (You may want to write some tests)

``` Bash
for ((i=0; i<512; i++)); do j+=($(head -c 16 /dev/urandom)); done
declare -p j > testdata
e=({a,A}{b,B}{c,C}{d,D}{e,E}{f,F}{g,G}{H,h}{i,I})
declare -p e >> testdata

for impl in ./quinedb_*; do
  TIMEFORMAT="$impl:"$'\nreal\t%R\nuser\t%U\nsys\t%S\n'
  time for ((i=0; i<32; i++)); do
    bash "$impl" set "${e[i]}" "${j[i]}" > qdb.out || break
    mv qdb.out "$impl"
  done
done
```

[testdata.txt](https://github.com/gfredericks/quinedb/files/477784/testdata.txt)

```
./quinedb_+=:
real    11.331
user    0.578
sys     10.609
DB IS LOSSY

./quinedb_pf:
real    10.937
user    0.328
sys     10.703
```

An example of byte-safety:

```
/tmp$ bash ./quinedb_pf get abcdefghi >/dev/null
$'\3257\327\354I\206\374\364\306\\\253\216,\234\005\370'
/tmp$ bash ./quinedb_+= get abcdefghi >/dev/null
$'7I\\'
```

Warning on newlines and grey-area undocumented behavior:

`printf %q` only gives _reusable_ strings, and there is no guarantee that the string will not contain newlines. The current (4.4) implementation does not produce newlines though:

``` C
/* bash-4.4/builtins/printf.def:575 */
if (p && *p == 0)        /* XXX - getstr never returns null */
  xp = savestring ("''");
else if (ansic_shouldquote (p))
  xp = ansic_quote (p, 0, (int *)0); // isprint('\n') == 0, so it always hits this branch
else
  xp = sh_backslash_quote (p, 0, 1); // even this branch has NL covered in lib/sh/shquote.c:bstab
```
